### PR TITLE
Added fix for UIScrollView issues with autolayout.

### DIFF
--- a/ImageScroll/ImageScrollViewController.m
+++ b/ImageScroll/ImageScrollViewController.m
@@ -64,6 +64,9 @@
 
   self.constraintTop.constant = vPadding;
   self.constraintBottom.constant = vPadding;
+    
+  // Makes zoom out animation smooth and starting from the right point not from (0, 0)
+  [self.view layoutIfNeeded];
 }
 
 // Zoom to show as much image as possible unless image is smaller than screen

--- a/ImageScroll/en.lproj/MainStoryboard.storyboard
+++ b/ImageScroll/en.lproj/MainStoryboard.storyboard
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="5056" systemVersion="13C1021" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="2">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6245" systemVersion="13F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="2">
     <dependencies>
-        <deployment defaultVersion="1792" identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3733"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6238"/>
     </dependencies>
     <scenes>
         <!--Image Scroll View Controller-->
@@ -26,15 +25,14 @@
                                 </subviews>
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                                 <constraints>
-                                    <constraint firstAttribute="trailing" secondItem="VYT-5l-DKu" secondAttribute="trailing" constant="110" id="3NM-Ag-kuw"/>
-                                    <constraint firstAttribute="bottom" secondItem="VYT-5l-DKu" secondAttribute="bottom" constant="234" id="OJJ-2N-lik"/>
+                                    <constraint firstItem="VYT-5l-DKu" firstAttribute="trailing" secondItem="OdA-la-nwK" secondAttribute="trailing" constant="-110" id="3NM-Ag-kuw"/>
+                                    <constraint firstItem="VYT-5l-DKu" firstAttribute="bottom" secondItem="OdA-la-nwK" secondAttribute="bottom" constant="-234" id="OJJ-2N-lik"/>
                                     <constraint firstItem="VYT-5l-DKu" firstAttribute="leading" secondItem="OdA-la-nwK" secondAttribute="leading" constant="110" id="WP6-ke-dAB"/>
                                     <constraint firstItem="VYT-5l-DKu" firstAttribute="top" secondItem="OdA-la-nwK" secondAttribute="top" constant="234" id="cBr-2i-6xb"/>
                                 </constraints>
                             </scrollView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ibs-K7-hcn">
                                 <rect key="frame" x="226" y="20" width="84" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Small image">
                                     <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                     <color key="titleShadowColor" red="0.059766057480000002" green="0.1305306312" blue="0.063332435790000002" alpha="1" colorSpace="calibratedRGB"/>


### PR DESCRIPTION
So, as I medtioned in issue #5 there are some troubles with iOS 8. It turned out that this can be easily fixed by inspecting constraints. Some of them (those responisble for resizing `UIImageView`) has pinned `imageView` as a second view and `scrollView` as a first view - it should be reversed. It's strange because iOS 7 doesn't have any problems with translating those.
